### PR TITLE
Add CLI and packaging for simplified build and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,45 +23,53 @@ A comprehensive tool for reverse engineering binary files (DLL, SYS, EXE) and ge
 
 ## Installation
 
-### Prerequisites
-- Python 3.7 or higher
-- Windows environment (for PE file analysis)
+### Quick install
+The project now ships with a standard Python packaging workflow. Install it straight from the repository root:
 
-### Install Dependencies
-```powershell
-cd c:\Users\kelly\darpa
-pip install -r requirements.txt
+```bash
+pip install .
 ```
 
-### Required Python Packages
-- `capstone`: Disassembly engine
-- `pefile`: PE file parser
-- `pyelftools`: ELF file support (future enhancement)
-- `pygments`: Syntax highlighting
-- `click`: Command-line interface
-- `jinja2`: Template engine
+The command automatically pulls in every dependency listed in `pyproject.toml`, so no manual `pip install -r requirements.txt` step is required.
+
+### Editable/development install
+If you intend to modify the code base, install it in editable mode instead:
+
+```bash
+git clone https://github.com/your-org/pydecomp.git
+cd pydecomp
+pip install -e .
+```
+
+Both commands work on Windows, Linux and macOS as long as Python 3.8+ is available.
 
 ## Usage
 
 ### Basic Usage
-```powershell
+The packaging step exposes a `pydecomp` console script that wraps the full pipeline:
+
+```bash
 # Analyze a DLL file
-python enhanced_disassembler.py sample.dll
+pydecomp analyze sample.dll
 
 # Analyze with full reporting
-python enhanced_disassembler.py sample.dll --report --strings
+pydecomp analyze sample.dll --report --strings
 
-# Generate build files
-python enhanced_disassembler.py sample.dll --build-files
+# Generate build files alongside the reconstructed source
+pydecomp analyze sample.dll --build-files
 ```
 
 ### Advanced Usage
-```powershell
+```bash
 # Complete analysis with custom output directory
-python enhanced_disassembler.py malware.exe -o analysis_results --report --strings --build-files --detailed
+pydecomp analyze malware.exe -o analysis_results --report --strings --build-files --detailed
 
-# Quick analysis for large files
-python enhanced_disassembler.py large_driver.sys -o quick_analysis
+# Quick analysis for large files while capping the amount of discovered functions
+pydecomp analyze large_driver.sys -o quick_analysis --max-functions 40
+
+# Validate and build the generated project (requires a C/C++ toolchain)
+pydecomp validate analysis_results
+pydecomp build analysis_results --system cmake
 ```
 
 ### Command Line Options
@@ -77,10 +85,11 @@ python enhanced_disassembler.py large_driver.sys -o quick_analysis
 ### Generated Files
 1. **`[filename].h`**: Header file with function declarations and data structures
 2. **`[filename].cpp`**: C++ implementation with reconstructed functions
-3. **`[filename]_analysis_report.txt`**: Detailed analysis report (with --report)
-4. **`[filename]_summary.json`**: JSON summary of analysis results
-5. **`Makefile`**: Build file for GCC/MinGW (with --build-files)
-6. **`CMakeLists.txt`**: CMake build configuration (with --build-files)
+3. **`[filename]_perfect.h` / `[filename]_perfect.c`**: Perfect C recreation output
+4. **`[filename]_analysis_report.txt`**: Detailed analysis report (with `--report`)
+5. **`[filename]_summary.json`**: JSON summary of analysis results
+6. **`Makefile`**: Build file for GCC/MinGW (with `--build-files`)
+7. **`CMakeLists.txt`**: CMake build configuration (with `--build-files`)
 
 ### Example Output Structure
 ```
@@ -197,8 +206,8 @@ Includes signatures for common Windows APIs:
 ## Examples
 
 ### Example 1: Simple DLL Analysis
-```powershell
-python enhanced_disassembler.py simple.dll --report
+```bash
+pydecomp analyze simple.dll --report
 ```
 
 This generates:
@@ -207,15 +216,15 @@ This generates:
 - `simple_analysis_report.txt` with detailed analysis
 
 ### Example 2: Driver Analysis
-```powershell
-python enhanced_disassembler.py driver.sys -o driver_analysis --strings --build-files
+```bash
+pydecomp analyze driver.sys -o driver_analysis --strings --build-files
 ```
 
 This creates a complete analysis package with build files.
 
 ### Example 3: Malware Analysis
-```powershell
-python enhanced_disassembler.py suspicious.exe -o malware_analysis --detailed --report --strings
+```bash
+pydecomp analyze suspicious.exe -o malware_analysis --detailed --report --strings
 ```
 
 This performs comprehensive analysis suitable for malware research.

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -14,18 +14,18 @@ You now have a powerful binary reverse engineering tool that can:
 ## Quick Start
 
 ### Basic Analysis
-```powershell
-python enhanced_disassembler.py target.dll
+```bash
+pydecomp analyze target.dll
 ```
 
 ### Complete Analysis
-```powershell
-python enhanced_disassembler.py target.dll --report --strings --build-files
+```bash
+pydecomp analyze target.dll --report --strings --build-files
 ```
 
 ### Custom Output Directory
-```powershell
-python enhanced_disassembler.py target.dll -o my_analysis --report --strings
+```bash
+pydecomp analyze target.dll -o my_analysis --report --strings
 ```
 
 ## What the Tool Generates
@@ -88,7 +88,7 @@ The tool automatically categorizes functions:
 
 ### Session 1: Analyzing a System DLL
 ```powershell
-PS C:\Users\kelly\darpa> python enhanced_disassembler.py C:\Windows\System32\winmm.dll -o winmm_analysis --report --strings --build-files
+PS C:\Users\kelly\darpa> pydecomp analyze C:\Windows\System32\winmm.dll -o winmm_analysis --report --strings --build-files
 
 Enhanced Binary Analysis Tool
 Analyzing: C:\Windows\System32\winmm.dll

--- a/pydecomp_cli.py
+++ b/pydecomp_cli.py
@@ -1,0 +1,166 @@
+"""Command line interface that wraps the enhanced binary analyzer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from build_system import AutomatedBuilder, CodeValidator, CompilerDetector
+from enhanced_disassembler import run_analysis
+
+
+def _echo_progress(message: str) -> None:
+    """Helper used to forward progress messages to Click."""
+
+    click.echo(message)
+
+
+@click.group()
+def cli() -> None:
+    """Binary analysis toolkit with build helpers."""
+
+
+@cli.command()
+@click.argument("binary_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--output", "output_dir", default="output", show_default=True,
+              type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+              help="Directory where analysis artefacts will be written.")
+@click.option("--report/--no-report", default=False, show_default=True,
+              help="Generate the detailed analysis report text file.")
+@click.option("--strings/--no-strings", default=False, show_default=True,
+              help="Extract and analyse printable strings from the binary.")
+@click.option("--build-files/--no-build-files", default=False, show_default=True,
+              help="Emit Makefile and CMakeLists.txt build helpers.")
+@click.option("--detailed/--no-detailed", default=False, show_default=True,
+              help="Reserved flag for future extended analysis.")
+@click.option("--complete/--no-complete", default=False, show_default=True,
+              help="Reserved flag for deeper disassembly workflows.")
+@click.option("--max-functions", default=100, show_default=True,
+              help="Limit the number of automatically discovered functions to inspect.")
+def analyze(
+    binary_path: Path,
+    output_dir: Path,
+    report: bool,
+    strings: bool,
+    build_files: bool,
+    detailed: bool,
+    complete: bool,
+    max_functions: int,
+) -> None:
+    """Analyse *BINARY_PATH* and regenerate C/C++ artefacts."""
+
+    click.echo("Enhanced Binary Analysis Tool")
+    click.echo(f"Analyzing: {binary_path}")
+    click.echo(f"Output: {output_dir}")
+    click.echo("-" * 50)
+
+    try:
+        result = run_analysis(
+            str(binary_path),
+            str(output_dir),
+            report=report,
+            strings=strings,
+            build_files=build_files,
+            detailed=detailed,
+            complete=complete,
+            max_functions=max_functions,
+            progress_callback=_echo_progress,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo("-" * 50)
+    click.echo("Generated files:")
+    for label, filepath in result["generated_files"].items():
+        pretty_label = label.replace("_", " ").title()
+        click.echo(f"- {pretty_label}: {filepath}")
+
+    click.echo("")
+    click.echo("Key statistics:")
+    stats = result["summary"]["analysis_stats"]
+    click.echo(f"- Sections: {stats['sections']}")
+    click.echo(f"- Imports: {stats['imports']}")
+    click.echo(f"- Exports: {stats['exports']}")
+    click.echo(f"- Functions analysed: {stats['functions_analyzed']}")
+    click.echo(f"- Strings found: {stats['strings_found']}")
+
+    click.echo("")
+    click.echo("Analysis complete! 🎉")
+    click.echo(f"Summary saved to: {result['generated_files']['summary']}")
+
+
+def _build_compiler_detector() -> CompilerDetector:
+    detector = CompilerDetector()
+    available = detector.get_available_compilers()
+    if not available:
+        raise click.ClickException("No supported C/C++ compiler was detected on this system.")
+    return detector
+
+
+@cli.command()
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option(
+    "--system",
+    "build_system",
+    type=click.Choice(["auto", "cmake", "make", "msvc", "simple"], case_sensitive=False),
+    default="auto",
+    show_default=True,
+    help="Build system to use for compiling generated artefacts.",
+)
+def build(project_dir: Path, build_system: str) -> None:
+    """Compile the generated code located in *PROJECT_DIR*."""
+
+    detector = _build_compiler_detector()
+    builder = AutomatedBuilder(detector)
+    click.echo(f"Building project in {project_dir} using '{build_system}' mode...")
+
+    result = builder.build_project(project_dir, build_system=build_system.lower())
+
+    if not result.get("success", False):
+        stderr = result.get("stderr") or result.get("error")
+        raise click.ClickException(stderr or "Build failed")
+
+    click.echo("Build succeeded!")
+    if result.get("output_dir"):
+        click.echo(f"Build artefacts are available in: {result['output_dir']}")
+
+
+@cli.command()
+@click.argument("project_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+def validate(project_dir: Path) -> None:
+    """Run a syntax check over all C/C++ files in *PROJECT_DIR*."""
+
+    detector = _build_compiler_detector()
+
+    validator = CodeValidator(detector)
+    click.echo(f"Validating source files in {project_dir}...")
+    result = validator.validate_project(project_dir)
+
+    if not result.get("project_valid", False):
+        error = result.get("error", "Project validation failed")
+        raise click.ClickException(error)
+
+    file_results = result.get("file_results", {})
+    for filename, file_result in file_results.items():
+        status = "passed" if file_result.get("success") else "failed"
+        click.echo(f"- {filename}: {status}")
+        for warning in file_result.get("warnings", []):
+            click.echo(f"  ⚠️  {warning}")
+        for error in file_result.get("errors", []):
+            click.echo(f"  ❌ {error}")
+
+    summary = {
+        "files_validated": result.get("files_validated", 0),
+        "errors": result.get("summary", {}).get("total_errors", 0),
+        "warnings": result.get("summary", {}).get("total_warnings", 0),
+    }
+
+    click.echo("")
+    click.echo("Validation summary:")
+    click.echo(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pydecomp"
+version = "0.1.0"
+description = "Binary disassembler and C/C++ recreation toolkit"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{ name = "PyDecomp Contributors" }]
+keywords = ["reverse engineering", "disassembler", "binary analysis"]
+dependencies = [
+    "capstone==5.0.1",
+    "pefile==2023.2.7",
+    "pyelftools==0.31",
+    "pygments==2.17.2",
+    "click==8.1.7",
+    "jinja2==3.1.4",
+    "tkinter-tooltip>=2.0.0",
+    "pillow>=9.0.0",
+    "setuptools>=65",
+]
+
+[project.scripts]
+pydecomp = "pydecomp_cli:cli"
+
+[tool.setuptools]
+py-modules = [
+    "binary_disassembler",
+    "build_system",
+    "code_editor",
+    "code_generator",
+    "complete_demo",
+    "complete_disassembler",
+    "control_flow_analyzer",
+    "demo_gui",
+    "enhanced_code_generator",
+    "enhanced_disassembler",
+    "enhanced_pattern_analyzer",
+    "gui_analyzer",
+    "gui_main",
+    "pattern_analyzer",
+    "perfect_c_generator",
+    "project_manager",
+    "run_gui",
+    "settings_manager",
+    "pydecomp_cli",
+]

--- a/setup.bat
+++ b/setup.bat
@@ -29,7 +29,7 @@ if errorlevel 1 (
 
 echo.
 echo Installing required packages...
-pip install -r requirements.txt
+pip install .
 
 if errorlevel 1 (
     echo ERROR: Failed to install dependencies
@@ -47,16 +47,16 @@ echo Usage Examples:
 echo ===============
 echo.
 echo Basic analysis:
-echo   python enhanced_disassembler.py sample.dll
+echo   pydecomp analyze sample.dll
 echo.
 echo Full analysis with report:
-echo   python enhanced_disassembler.py sample.dll --report --strings
+echo   pydecomp analyze sample.dll --report --strings
 echo.
 echo Complete analysis with build files:
-echo   python enhanced_disassembler.py sample.exe -o analysis --report --strings --build-files
+echo   pydecomp analyze sample.exe -o analysis --report --strings --build-files
 echo.
 echo Testing the tool:
-echo   python test_tool.py
+echo   pydecomp validate analysis
 echo.
 
 REM Ask if user wants to run a test


### PR DESCRIPTION
## Summary
- add a pyproject-based packaging configuration and expose a `pydecomp` console entry point
- extract a reusable `run_analysis` helper and augment the analyzer for configurable function discovery
- document the new installation and CLI workflow and refresh the Windows setup script

## Testing
- pip install -e .
- pydecomp --help

------
https://chatgpt.com/codex/tasks/task_e_68ca4ff8d0348322b73ea92207b2fff8